### PR TITLE
fixed polish, added missing serbian translation, changed battery list…

### DIFF
--- a/res/values-pl-rPL/urom_strings.xml
+++ b/res/values-pl-rPL/urom_strings.xml
@@ -14,14 +14,14 @@
     <string name="urom_screen_adaptive">Automatyczny</string>
     <string name="urom_settings_title">Różne ustawienia</string>
     <string name="urom_other_category">Inne</string>
-    <string name="urom_about">Informacje o ROM'ie</string>
+    <string name="urom_about">Informacje o ROM\'ie</string>
  
     <!-- Ram minfree -->
     <string name="ram_minfree_title">Zarządca Poziomu Pamięci (LMK) (*)</string>
     <string name="ram_minfree_automatic">Automatyczny</string>
  
     <!-- zram -->
-    <string name="zram_size_title">Ilość Swap'u w pamięci (*)</string>
+    <string name="zram_size_title">Ilość Swap\'u w pamięci (*)</string>
  
     <!-- lightbar -->
     <string name="lightbar_mode_title">Podświetlenie przycisków (*)</string>

--- a/res/values-pl/urom_strings.xml
+++ b/res/values-pl/urom_strings.xml
@@ -14,14 +14,14 @@
     <string name="urom_screen_adaptive">Automatyczny</string>
     <string name="urom_settings_title">Różne ustawienia</string>
     <string name="urom_other_category">Inne</string>
-    <string name="urom_about">Informacje o ROM'ie</string>
+    <string name="urom_about">Informacje o ROM\'ie</string>
  
     <!-- Ram minfree -->
     <string name="ram_minfree_title">Zarządca Poziomu Pamięci (LMK) (*)</string>
     <string name="ram_minfree_automatic">Automatyczny</string>
  
     <!-- zram -->
-    <string name="zram_size_title">Ilość Swap'u w pamięci (*)</string>
+    <string name="zram_size_title">Ilość Swap\'u w pamięci (*)</string>
  
     <!-- lightbar -->
     <string name="lightbar_mode_title">Podświetlenie przycisków (*)</string>

--- a/res/values-sr/urom_strings.xml
+++ b/res/values-sr/urom_strings.xml
@@ -39,6 +39,10 @@
     <!-- hw keys music -->
     <string name="mainkeys_music_title">Физички тастери за музику (*)</string>
     <string name="mainkeys_music_summary">Контрола музике када је екран искључен</string>
+
+    <!-- Navigation Bar -->
+    <string name="mainkeys_navbar_title">Трака за навигацију (*)</string>
+    <string name="mainkeys_navbar_summary">Тастери на екрану</string>
  
     <!-- doze -->
     <string name="doze_brightness_title">Ниво амбијенталног осветљења (*)</string>
@@ -54,6 +58,9 @@
  
     <!-- fast charge -->
     <string name="fast_charge">USB брзо пуњење</string>
+
+    <!-- batery stats -->
+    <string name="power_usage_list_summary_time_suffix">(%1$dч %2$dм)</string>
  
     <!-- BitSyko Layers -->
     <string name="bitsyko_layers">Layers</string>

--- a/res/values/urom_strings.xml
+++ b/res/values/urom_strings.xml
@@ -60,7 +60,7 @@
     <string name="fast_charge">USB Fast Charge</string>
 
     <!-- batery stats -->
-    <string name="power_usage_list_summary_time">Use since last full charge (%1$dh %2$dm)</string>
+    <string name="power_usage_list_summary_time_suffix">(%1$dh %2$dm)</string>
  
     <!-- BitSyko Layers -->
     <string name="bitsyko_layers">Layers</string>

--- a/src/com/android/settings/fuelgauge/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageSummary.java
@@ -317,7 +317,8 @@ public class PowerUsageSummary extends PowerUsageBase {
         int statsMinutes = (int)(uSecTime / (1000 * 1000 * 60));
         int statsHours = statsMinutes / 60;
         statsMinutes = statsMinutes % 60;
-        mAppListGroup.setTitle(getString(R.string.power_usage_list_summary_time, statsHours, statsMinutes));
+        mAppListGroup.setTitle(getString(R.string.power_usage_list_summary) + " "
+                + getString(R.string.power_usage_list_summary_time_suffix, statsHours, statsMinutes));
 
         if (averagePower >= MIN_AVERAGE_POWER_THRESHOLD_MILLI_AMP || USE_FAKE_DATA) {
             final List<BatterySipper> usageList = getCoalescedUsageList(


### PR DESCRIPTION
changed battery list summary to use resource from strings.xml
- Battery stats app list summary is already translated in strings.xml file, so urom-strings needs only suffix translation (?h ?s)
